### PR TITLE
Worker clears locks on shutdown [PLAT-1593]

### DIFF
--- a/lib/delayed/heartbeat/worker.rb
+++ b/lib/delayed/heartbeat/worker.rb
@@ -38,6 +38,11 @@ module Delayed
         orphaned_jobs
       end
 
+      # Unlocks jobs held by the worker as an atomic operation.
+      def clear_locks
+        jobs.update_all(locked_at: nil, locked_by: nil)
+      end
+
       def self.dead_workers(timeout_seconds)
         where('last_heartbeat_at < ?', Time.now.utc - timeout_seconds)
       end

--- a/spec/db/database.yml
+++ b/spec/db/database.yml
@@ -2,4 +2,9 @@ sqlite3:
   adapter: sqlite3
   pool: 5
   timeout: 15000
+  # The checkout_timeout determines how long we wait before forcing a
+  # disconnect on an in-use connection. We rely on this behavior when
+  # testing shutting down workers, so this is set to a small value to
+  # ensure the tests run fast.
+  checkout_timeout: 0.01
   database: tmp/sqlite3.db

--- a/spec/delayed/heartbeat/worker_heartbeat_spec.rb
+++ b/spec/delayed/heartbeat/worker_heartbeat_spec.rb
@@ -39,6 +39,11 @@ describe Delayed::Heartbeat::WorkerHeartbeat, cleaner_strategy: :truncation do
     it "destroys the worker model" do
       expect(find_worker_model(worker_name)).not_to be_present
     end
+
+    it "unlocks the worker jobs" do
+      expect(job.reload.locked_by).to be_nil
+      expect(job.reload.locked_at).to be_nil
+    end
   end
 
   context "when the heartbeat times out" do


### PR DESCRIPTION
In some cases the ClearLocks plugin from Delayed::Job may fail to clear
the locked_at/locked_by fields on a job because it was interrupted at a
bad time (see [PLAT-1590](https://salsify.atlassian.net/browse/PLAT-1590)). The delayed_worker is still removed since
the heartbeat is using a separate connection, leaving orphaned jobs
behind that are not re-run until the 4 hour max run time has passed.

This change will require the worker to clear its own locks when it is
shutting down before it removes itself from the delayed_workers table.

[PLAT-1593](https://salsify.atlassian.net/browse/PLAT-1593)

Prime: @fgarces 
cc @jturkel 