### PR TITLE
Rails 7.2 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- Add support for Rails 7.2
+
 ## 0.5.0
 
 - Drop support for ruby < 2.7

--- a/lib/delayed/heartbeat/worker_heartbeat.rb
+++ b/lib/delayed/heartbeat/worker_heartbeat.rb
@@ -46,7 +46,7 @@ module Delayed
           update_heartbeat
           # Return the connection back to the pool since we won't be needing
           # it again for a while.
-          Delayed::Backend::ActiveRecord::Job.clear_active_connections!
+          Delayed::Backend::ActiveRecord::Job.connection_handler.clear_active_connections!
         end
       rescue StandardError => e
         # We don't want the worker to continue running if the heartbeat can't be written.
@@ -59,7 +59,7 @@ module Delayed
         @stop_reader.close
         @worker_model.delete
         # Note: The built-in Delayed::Plugins::ClearLocks will unlock the jobs for us
-        Delayed::Backend::ActiveRecord::Job.clear_active_connections!
+        Delayed::Backend::ActiveRecord::Job.connection_handler.clear_active_connections!
       end
 
       def update_heartbeat


### PR DESCRIPTION
See https://guides.rubyonrails.org/7_1_release_notes.html#active-record-deprecations :
- Deprecate delegation from Base to connection_handler.